### PR TITLE
feat: easier deleting message of the bot

### DIFF
--- a/bot/discordPages.go
+++ b/bot/discordPages.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
@@ -69,6 +70,13 @@ func formatForMessage(page *ReactionListener) string {
 
 // ReactionListen listens for the reactions for a previously sent embed.
 func ReactionListen(session *discordgo.Session, reaction *discordgo.MessageReactionAdd) {
+	// Shortcut to delete self embed
+	if reaction.UserID != session.State.Ready.User.ID && reaction.Emoji.Name == destroyEmoji {
+		if err := session.ChannelMessageDelete(reaction.ChannelID, reaction.MessageID); err != nil {
+			log.Printf("could not delete message: %s", err)
+		}
+	}
+
 	// if the message being reacted to is in the reaction map
 	if _, ok := pageListeners[reaction.MessageID]; ok {
 		// validating that the user reacting is indeed the user that owns the listener

--- a/bot/handlers.go
+++ b/bot/handlers.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -42,7 +43,15 @@ func HandleDoc(s *discordgo.Session, m *discordgo.MessageCreate, prefix string) 
 	if msg == nil {
 		msg = errResponse("No results found, possibly an internal error.")
 	}
-	s.ChannelMessageSendEmbed(m.ChannelID, msg)
+	new_m, err := s.ChannelMessageSendEmbed(m.ChannelID, msg)
+	if err != nil {
+		log.Printf("could not send message: %s", err)
+	}
+
+	err = s.MessageReactionAdd(new_m.ChannelID, new_m.ID, destroyEmoji)
+	if err != nil {
+		log.Printf("could not send message: %s", err)
+	}
 }
 
 // queryResponse generates the response for a query.

--- a/bot/handlers.go
+++ b/bot/handlers.go
@@ -43,12 +43,12 @@ func HandleDoc(s *discordgo.Session, m *discordgo.MessageCreate, prefix string) 
 	if msg == nil {
 		msg = errResponse("No results found, possibly an internal error.")
 	}
-	new_m, err := s.ChannelMessageSendEmbed(m.ChannelID, msg)
+	embedM, err := s.ChannelMessageSendEmbed(m.ChannelID, msg)
 	if err != nil {
 		log.Printf("could not send message: %s", err)
 	}
 
-	err = s.MessageReactionAdd(new_m.ChannelID, new_m.ID, destroyEmoji)
+	err = s.MessageReactionAdd(embedM.ChannelID, embedM.ID, destroyEmoji)
 	if err != nil {
 		log.Printf("could not send message: %s", err)
 	}


### PR DESCRIPTION
The bot automatically reacts to its own messages with a ❌.

Any user can delete the bot's messages.

I haven't handled the fact that the bot tries to delete other's messages, as I haven't found my way around that.

I might have to rewrite the pagination stuff so it can handle that.