### PR TITLE
Trim embed down to title/url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.txt
 *.html
 *.json
+
+/dr-docso

--- a/bot/discordPages.go
+++ b/bot/discordPages.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+
 	"github.com/post04/dr-docso/docs"
 )
 
@@ -148,9 +149,13 @@ func ReactionListen(session *discordgo.Session, reaction *discordgo.MessageReact
 	if err != nil {
 		return
 	}
-	if msg.Author.ID == session.State.User.ID {
-		if err := session.ChannelMessageDelete(reaction.ChannelID, reaction.MessageID); err != nil {
-			log.Printf("could not delete message: %s", err)
+	if msg.Author.ID == session.State.User.ID && len(msg.Embeds) > 0 {
+		edit := &discordgo.MessageEmbed{
+			Title: msg.Embeds[0].Title,
+			URL:   msg.Embeds[0].URL,
+		}
+		if _, err := session.ChannelMessageEditEmbed(reaction.ChannelID, reaction.MessageID, edit); err != nil {
+			log.Printf("could not edit message: %s", err)
 		}
 	}
 }


### PR DESCRIPTION
Resolves #7 

Unfortunately, due to `omitempty` I don't know of a way to remove the embed without deleting the message.  
However, then a new message would need to be sent.

If you prefer that, feel free to let me know or close this PR.

This PR edits the embed and trims it down to just the title/url.

![Screenshot from 2021-04-15 23-06-40](https://user-images.githubusercontent.com/42128690/114970064-486a8200-9e3f-11eb-921c-7c064586bd91.png)
